### PR TITLE
Pi2 - Fix large gaps in SPI0 outputed bytes and remove buffer limitations

### DIFF
--- a/drivers/spi/bcm2836/bcmspi.h
+++ b/drivers/spi/bcm2836/bcmspi.h
@@ -132,17 +132,9 @@ BCM_SPI_REGISTERS, *PBCM_SPI_REGISTERS;
 #define BCM_SPI_REG_DC_TDREQ            0x000000ff
 #define BCM_SPI_REG_DC_TDREQ_SET(v)     ((v) & BCM_SPI_REG_DC_TDREQ)
 
-#define BCM_SPI_MAX_TRANSFER_LENGTH 0x00010000
-
 // Number of clocks it takes the SPI HW to clock 1 byte
 // The SPI HW waits an extra clock after each byte transfered
 #define BCM_SPI_SCLK_TICKS_PER_BYTE 9
-
-// The transfer time threshold for small transfers for which Polling
-// is appropriate
-// For now, do everything polling, once DMA implemented specify proper
-// time limit based on expirmentation
-#define BCM_SPI_TRANSFER_POLL_LIMIT_US  MAXULONGLONG
 
 #endif
 

--- a/drivers/spi/bcm2836/bcmspi.vcxproj
+++ b/drivers/spi/bcm2836/bcmspi.vcxproj
@@ -77,8 +77,8 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <EnablePREfast>true</EnablePREfast>
-      <WppRecorderEnabled>false</WppRecorderEnabled>
-      <WppEnabled>false</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppEnabled>true</WppEnabled>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -110,7 +110,7 @@
   </ItemGroup>
   <!-- Necessary to pick up proper files from local directory when in the IDE-->
   <ItemGroup>
-    <None Exclude="@(None)" Include="*.txt;*.htm;*.html" />
+    <None Include="License.txt" />
     <None Exclude="@(None)" Include="*.ico;*.cur;*.bmp;*.dlg;*.rct;*.gif;*.jpg;*.jpeg;*.wav;*.jpe;*.tiff;*.tif;*.png;*.rc2" />
     <None Exclude="@(None)" Include="*.def;*.bat;*.hpj;*.asmx" />
   </ItemGroup>

--- a/drivers/spi/bcm2836/controller.h
+++ b/drivers/spi/bcm2836/controller.h
@@ -46,11 +46,11 @@ ControllerDoOneTransferPollMode(
     _Inout_ PPBC_REQUEST pRequest
     );
 
-VOID
+bool
 ControllerCompleteTransfer(
     _Inout_ PPBC_DEVICE pDevice,
     _Inout_ PPBC_REQUEST pRequest,
-    _In_ BOOLEAN AbortSequence
+    _In_ NTSTATUS TransferStatus
     );
 
 VOID
@@ -79,6 +79,16 @@ VOID
 ControllerConfigClock(
     PPBC_DEVICE pDevice,
     ULONG clockHz
+    );
+
+VOID
+ControllerActivateTransfer(
+    PPBC_DEVICE pDevice
+    );
+
+VOID
+ControllerDeactivateTransfer(
+    PPBC_DEVICE pDevice
     );
 
 #endif

--- a/drivers/spi/bcm2836/device.h
+++ b/drivers/spi/bcm2836/device.h
@@ -63,16 +63,11 @@ EVT_SPB_CONTROLLER_SEQUENCE          OnSequenceRequest;
 EVT_WDF_IO_IN_CALLER_CONTEXT         OnOtherInCallerContext;
 EVT_SPB_CONTROLLER_OTHER             OnOther;
 
+KSTART_ROUTINE TransferPollModeThread;
+
 //
 // PBC function prototypes.
 //
-
-NTSTATUS
-OnRequest(
-    _In_ PPBC_DEVICE pDevice,
-    _In_ PPBC_TARGET pTarget,
-    _In_ PPBC_REQUEST pRequest
-    );
 
 VOID
 OnNonSequenceRequest(
@@ -83,15 +78,22 @@ OnNonSequenceRequest(
     );
 
 NTSTATUS
+OnRequest(
+    _In_ PPBC_DEVICE pDevice,
+    _In_ PPBC_TARGET pTarget,
+    _In_ PPBC_REQUEST pRequest
+    );
+
+VOID
+OnRequestPollMode(
+    _In_ PPBC_DEVICE pDevice
+    );
+
+NTSTATUS
 PbcTargetGetSettings(
     _In_ PPBC_DEVICE  pDevice,
     _In_ PVOID ConnectionParameters,
     _Out_ PPBC_TARGET_SETTINGS pSettings
-    );
-
-NTSTATUS
-PbcRequestValidate(
-    _In_ PPBC_REQUEST pRequest
     );
 
 NTSTATUS
@@ -106,36 +108,12 @@ PbcRequestDoTransfer(
     _In_ PPBC_REQUEST pRequest
     );
 
-VOID
-PbcRequestComplete(
-    _In_ PPBC_DEVICE pDevice,
-    _In_ PPBC_REQUEST pRequest
+ULONGLONG
+PbcRequestEstimateAllTransfersTimeUs(
+    _In_ PPBC_TARGET pTarget,
+    _In_ PPBC_REQUEST pRequest,
+    bool CountTransferDelays
     );
-
-size_t
-FORCEINLINE
-PbcRequestGetTransferInfoRemaining(
-   _In_ PPBC_REQUEST pRequest
-   )
-/*++
- 
-  Routine Description:
-
-    This is a helper routine used to retrieve the 
-    number of bytes remaining in the current transfer.
-
-  Arguments:
-
-    pRequest - a pointer to the PBC request context
-
-  Return Value:
-
-    Bytes remaining in request
-
---*/
-{
-    return (pRequest->CurrentTransferLength - pRequest->CurrentTransferInformation);
-}
 
 NTSTATUS
 FORCEINLINE
@@ -213,13 +191,6 @@ MdlGetByte(
 
     return status;
 }
-
-ULONGLONG
-PbcRequestEstimateAllTransfersTimeUs(
-    _In_ PPBC_TARGET pTarget,
-    _In_ PPBC_REQUEST pRequest,
-    bool CountTransferDelays
-    );
 
 NTSTATUS
 FORCEINLINE

--- a/drivers/spi/bcm2836/driver.h
+++ b/drivers/spi/bcm2836/driver.h
@@ -31,6 +31,7 @@ DriverEntry(
     );    
 
 EVT_WDF_DRIVER_DEVICE_ADD       OnDeviceAdd;
+EVT_WDF_DEVICE_CONTEXT_CLEANUP  OnDeviceCleanup;
 EVT_WDF_OBJECT_CONTEXT_CLEANUP  OnDriverCleanup;
 
 #endif

--- a/drivers/spi/bcm2836/internal.h
+++ b/drivers/spi/bcm2836/internal.h
@@ -164,6 +164,10 @@ struct PBC_DEVICE
 
     // The power setting callback handle
     PVOID                           pMonitorPowerSettingHandle;
+
+    PVOID                           pTransferThread;
+    KEVENT                          TransferThreadWakeEvt;
+    LONG                            TransferThreadShutdown;
 };
 
 //
@@ -211,45 +215,27 @@ struct PBC_REQUEST
     // Total bytes transferred.
     size_t                         TotalInformation;
 
-    // Current status of the request.
-    NTSTATUS                       Status;
-    // Indicates that the last transfer in the request has been
-    // done and the request context is updated with information
-    // needed for the SPB request completion
-    bool                           bRequestComplete;
     size_t                         RequestLength;
 
     //
     // Variables that are reused for each transfer within
-    // a [sequence] request.
+    // each request.
     //
 
-    //
-    // For a read/write only simple request, this value is the size 
-    // of the input buffer or output buffer.
-    // For a sequence request, this member specifies the total number
-    // of bytes to be transferred in the sequence.
-    // For a fullduplex request, this member specifies the size of the
-    // maximum between input and ouput buffer.
-    //
-    size_t                         CurrentTransferLength;
     size_t                         CurrentTransferWriteLength;
     size_t                         CurrentTransferReadLength;
     PMDL                           pCurrentTransferWriteMdlChain;
     PMDL                           pCurrentTransferReadMdlChain;
+
     // Bytes read/written in the current transfer.
     size_t                         CurrentTransferInformation;
 
     // Position of the current transfer within
     // the sequence and its associated controller
     // settings.
-    SPB_REQUEST_SEQUENCE_POSITION  SequencePosition;
-
-    // Direction of the current transfer.
-    SPB_TRANSFER_DIRECTION         Direction;
-
-    // Time to delay before starting transfer.
-    ULONG                          DelayInUs;
+    SPB_REQUEST_SEQUENCE_POSITION  CurrentTransferSequencePosition;
+    SPB_TRANSFER_DIRECTION         CurrentTransferDirection;
+    ULONG                          CurrentTransferDelayInUs;
 };
 
 //


### PR DESCRIPTION
- Eliminate time gaps between transmitted bytes by redesiging the SPI driver to in polling mode rather than interrupt due to SPI hw not providing watermarks for the FIFOs.
- A large increase in bus utilization due to gaps elimination.
- Remove the transfer buffer limitation of 65536 bytes.
- Enable WPP tracing
